### PR TITLE
Add methods to batch delete guild and global commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 pubspec.lock
 .packages
 private_test.dart
+.vscode/

--- a/lib/src/interactions.dart
+++ b/lib/src/interactions.dart
@@ -280,14 +280,9 @@ class Interactions implements IInteractions {
   /// Deletes all guild commands for the specified guilds
   @override
   Future<void> deleteGuildCommands(List<Snowflake> guildIds) async {
-    List<Future<int>> futures = [];
-
-    for (final guildId in guildIds) {
-      futures.add(interactionsEndpoints.bulkOverrideGuildCommands(client.appId, guildId, []).length);
-    }
-
-    // Wait for all overrides to complete
-    await Future.wait(futures);
+    await Future.wait(
+      guildIds.map((guildId) => interactionsEndpoints.bulkOverrideGuildCommands(client.appId, guildId, []))
+    );
   }
 
   /// Fetches all global bots command

--- a/lib/src/interactions.dart
+++ b/lib/src/interactions.dart
@@ -280,9 +280,7 @@ class Interactions implements IInteractions {
   /// Deletes all guild commands for the specified guilds
   @override
   Future<void> deleteGuildCommands(List<Snowflake> guildIds) async {
-    await Future.wait(
-      guildIds.map((guildId) => interactionsEndpoints.bulkOverrideGuildCommands(client.appId, guildId, []).toList())
-    );
+    await Future.wait(guildIds.map((guildId) => interactionsEndpoints.bulkOverrideGuildCommands(client.appId, guildId, []).toList()));
   }
 
   /// Fetches all global bots command

--- a/lib/src/interactions.dart
+++ b/lib/src/interactions.dart
@@ -281,7 +281,7 @@ class Interactions implements IInteractions {
   @override
   Future<void> deleteGuildCommands(List<Snowflake> guildIds) async {
     await Future.wait(
-      guildIds.map((guildId) => interactionsEndpoints.bulkOverrideGuildCommands(client.appId, guildId, []))
+      guildIds.map((guildId) => interactionsEndpoints.bulkOverrideGuildCommands(client.appId, guildId, []).toList())
     );
   }
 

--- a/lib/src/interactions.dart
+++ b/lib/src/interactions.dart
@@ -55,8 +55,14 @@ abstract class IInteractions {
   /// Deletes global command
   Future<void> deleteGlobalCommand(Snowflake commandId);
 
+  /// Deletes all global commands
+  Future<void> deleteGlobalCommands();
+
   /// Deletes guild command
   Future<void> deleteGuildCommand(Snowflake commandId, Snowflake guildId);
+
+  /// Deletes all guild commands for the specified guilds
+  Future<void> deleteGuildCommands(List<Snowflake> guildIds);
 
   /// Fetches all global bots command
   Stream<ISlashCommand> fetchGlobalCommands();
@@ -263,9 +269,26 @@ class Interactions implements IInteractions {
   @override
   Future<void> deleteGlobalCommand(Snowflake commandId) => interactionsEndpoints.deleteGlobalCommand(client.appId, commandId);
 
+  /// Deletes all global commands
+  @override
+  Future<void> deleteGlobalCommands() async => interactionsEndpoints.bulkOverrideGlobalCommands(client.appId, []);
+
   /// Deletes guild command
   @override
   Future<void> deleteGuildCommand(Snowflake commandId, Snowflake guildId) => interactionsEndpoints.deleteGuildCommand(client.appId, commandId, guildId);
+
+  /// Deletes all guild commands for the specified guilds
+  @override
+  Future<void> deleteGuildCommands(List<Snowflake> guildIds) async {
+    List<Future<int>> futures = [];
+
+    for (final guildId in guildIds) {
+      futures.add(interactionsEndpoints.bulkOverrideGuildCommands(client.appId, guildId, []).length);
+    }
+
+    // Wait for all overrides to complete
+    await Future.wait(futures);
+  }
 
   /// Fetches all global bots command
   @override


### PR DESCRIPTION
I don't think that automatically deleting guild commands is feasible due to Discord not providing a way to batch fetch guild commands in a single request as discussed in #9.

This PR implements the solution proposed by @l7ssha, adding methods to batch delete guild commands as well. Batch delete was also added for global commands for consistency.