### PR TITLE
bug: Fix invalid stream declarations of events in IEventController

### DIFF
--- a/lib/src/internal/event_controller.dart
+++ b/lib/src/internal/event_controller.dart
@@ -7,56 +7,56 @@ import 'package:nyxx_interactions/src/models/slash_command.dart';
 
 abstract class IEventController implements Disposable {
   /// Emitted when a slash command is sent.
-  Stream<SlashCommandInteractionEvent> get onSlashCommand;
+  Stream<ISlashCommandInteractionEvent> get onSlashCommand;
 
   /// Emitted when a button interaction is received.
-  Stream<ButtonInteractionEvent> get onButtonEvent;
+  Stream<IButtonInteractionEvent> get onButtonEvent;
 
   /// Emitted when a dropdown interaction is received.
-  Stream<MultiselectInteractionEvent> get onMultiselectEvent;
+  Stream<IMultiselectInteractionEvent> get onMultiselectEvent;
 
   /// Emitted when a slash command is created by the user.
-  Stream<SlashCommand> get onSlashCommandCreated;
+  Stream<ISlashCommand> get onSlashCommandCreated;
 
   /// Emitted when a slash command is created by the user.
-  Stream<AutocompleteInteractionEvent> get onAutocompleteEvent;
+  Stream<IAutocompleteInteractionEvent> get onAutocompleteEvent;
 }
 
 class EventController implements IEventController {
   /// Emitted when a slash command is sent.
   @override
-  late final Stream<SlashCommandInteractionEvent> onSlashCommand;
+  late final Stream<ISlashCommandInteractionEvent> onSlashCommand;
 
   /// Emitted when a button interaction is received.
   @override
-  late final Stream<ButtonInteractionEvent> onButtonEvent;
+  late final Stream<IButtonInteractionEvent> onButtonEvent;
 
   /// Emitted when a dropdown interaction is received.
   @override
-  late final Stream<MultiselectInteractionEvent> onMultiselectEvent;
+  late final Stream<IMultiselectInteractionEvent> onMultiselectEvent;
 
   /// Emitted when a slash command is created by the user.
   @override
-  late final Stream<SlashCommand> onSlashCommandCreated;
+  late final Stream<ISlashCommand> onSlashCommandCreated;
 
   /// Emitted when a slash command is created by the user.
   @override
-  late final Stream<AutocompleteInteractionEvent> onAutocompleteEvent;
+  late final Stream<IAutocompleteInteractionEvent> onAutocompleteEvent;
 
   /// Emitted when a a slash command is sent.
-  late final StreamController<SlashCommandInteractionEvent> onSlashCommandController;
+  late final StreamController<ISlashCommandInteractionEvent> onSlashCommandController;
 
   /// Emitted when a a slash command is sent.
-  late final StreamController<SlashCommand> onSlashCommandCreatedController;
+  late final StreamController<ISlashCommand> onSlashCommandCreatedController;
 
   /// Emitted when button event is sent
-  late final StreamController<ButtonInteractionEvent> onButtonEventController;
+  late final StreamController<IButtonInteractionEvent> onButtonEventController;
 
   /// Emitted when dropdown event is sent
-  late final StreamController<MultiselectInteractionEvent> onMultiselectEventController;
+  late final StreamController<IMultiselectInteractionEvent> onMultiselectEventController;
 
   /// Emitted when autocomplete interaction event is sent
-  late final StreamController<AutocompleteInteractionEvent> onAutocompleteEventController;
+  late final StreamController<IAutocompleteInteractionEvent> onAutocompleteEventController;
 
   /// Creates na instance of [EventController]
   EventController() {


### PR DESCRIPTION
# Description

Fix invalid stream declarations of events in IEventController

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
