### PR TITLE
Add target_id field

### DIFF
--- a/lib/src/models/interaction.dart
+++ b/lib/src/models/interaction.dart
@@ -137,6 +137,9 @@ abstract class ISlashCommandInteraction implements IInteraction {
 
   /// Additional data for command
   late final IInteractionDataResolved? resolved;
+
+  /// Id of the target entity (only present in message or user interactions)
+  Snowflake? get targetId;
 }
 
 /// Interaction for slash command
@@ -157,6 +160,9 @@ class SlashCommandInteraction extends Interaction implements ISlashCommandIntera
   @override
   late final IInteractionDataResolved? resolved;
 
+  @override
+  late final Snowflake? targetId;
+
   /// Creates na instance of [SlashCommandInteraction]
   SlashCommandInteraction(INyxx client, RawApiMap raw) : super(client, raw) {
     name = raw["data"]["name"] as String;
@@ -167,6 +173,8 @@ class SlashCommandInteraction extends Interaction implements ISlashCommandIntera
     commandId = Snowflake(raw["data"]["id"]);
 
     resolved = raw["data"]["resolved"] != null ? InteractionDataResolved(raw["data"]["resolved"] as RawApiMap, guild?.id, client) : null;
+
+    targetId = raw["data"]["target_id"] != null ? Snowflake(raw["data"]["target_id"]) : null;
   }
 
   /// Allows to fetch argument value by argument name


### PR DESCRIPTION
# Description

Added support for `target_id` field. Closes #27.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
