### PR TITLE
Clarify that getArg throws in ISlashCommandInteractionEvent

### DIFF
--- a/lib/src/events/interaction_event.dart
+++ b/lib/src/events/interaction_event.dart
@@ -240,7 +240,7 @@ class SlashCommandInteractionEvent extends InteractionEventWithAcknowledge<Slash
   List<IInteractionOption> get args => UnmodifiableListView(extractArgs(interaction.options));
 
   /// Searches for arg with [name] in this interaction.
-  /// 
+  ///
   /// Throws if [name] was not found in this interaction; if you want to look up the value of [name] and return `null` if it was not provided, use
   /// [interaction.getArg] instead.
   @override

--- a/lib/src/events/interaction_event.dart
+++ b/lib/src/events/interaction_event.dart
@@ -239,7 +239,10 @@ class SlashCommandInteractionEvent extends InteractionEventWithAcknowledge<Slash
   @override
   List<IInteractionOption> get args => UnmodifiableListView(extractArgs(interaction.options));
 
-  /// Searches for arg with [name] in this interaction
+  /// Searches for arg with [name] in this interaction.
+  /// 
+  /// Throws if [name] was not found in this interaction; if you want to look up the value of [name] and return `null` if it was not provided, use
+  /// [interaction.getArg] instead.
   @override
   IInteractionOption getArg(String name) => args.firstWhere((element) => element.name == name);
 


### PR DESCRIPTION
# Description

Clarifies the behaviour of `ISlashCommandInteractionEvent.getArg` as it behaves differently to `ISlashCommandInteraction.getArg`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
