### PR TITLE
Fix ignoring shouldSync for guild command permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.0-dev.0.1
+__10.2.2022__
+
+- bug: Fix guild slash command permissions being overridden even if the sync rule denies sync
+
 ## 4.0.0-dev.0
 
 - feature: Implement modals

--- a/lib/src/interactions.dart
+++ b/lib/src/interactions.dart
@@ -189,13 +189,13 @@ class Interactions implements IInteractions {
         for (final command in response) {
           _commands.add(command);
         }
+
+        await interactionsEndpoints.bulkOverrideGuildCommandsPermissions(client.appId, entry.key, entry.value);
       }
 
       for (final globalCommandBuilder in entry.value) {
         _assignCommandToHandler(globalCommandBuilder);
       }
-
-      await interactionsEndpoints.bulkOverrideGuildCommandsPermissions(client.appId, entry.key, entry.value);
     }
 
     if (_commandHandlers.isNotEmpty) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx_interactions
-version: 4.0.0-dev.0
+version: 4.0.0-dev.0.1
 description: Nyxx Interactions Module. Discord library for Dart. Simple, robust framework for creating discord bots for Dart language.
 homepage: https://github.com/nyxx-discord/nyxx
 repository: https://github.com/nyxx-discord/nyxx


### PR DESCRIPTION
# Description

Fixes an issue where guild command permissions are overridden even if the sync rule denies syncing, causing ratelimiting and hanging in some cases.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
