### PR TITLE
Add disabled option to `MultiselectBuilder`

### DIFF
--- a/lib/src/builders/component_builder.dart
+++ b/lib/src/builders/component_builder.dart
@@ -68,6 +68,9 @@ class MultiselectBuilder extends ComponentBuilderAbstract {
   /// Default: 1, min: 1, max: 25
   int? maxValues;
 
+  /// Whether disable the select menu.
+  bool? disabled;
+
   /// Creates instance of [MultiselectBuilder]
   MultiselectBuilder(this.customId, [Iterable<MultiselectOptionBuilder>? options]) {
     if (customId.length > 100) {
@@ -90,6 +93,7 @@ class MultiselectBuilder extends ComponentBuilderAbstract {
         if (placeholder != null) "placeholder": placeholder,
         if (minValues != null) "min_values": minValues,
         if (maxValues != null) "max_values": maxValues,
+        if (disabled != null) "disabled": disabled,
       };
 }
 


### PR DESCRIPTION
# Description

Add an option to disable the select menu, this option is referenced on [discord's documentation](https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure)

## Type of changes

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
