### PR TITLE
Implement application level permission overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.2.1
+__02.05.2022__
+
+- bug: Allow application level permission overrides
+
 ## 4.2.0
 __29.04.2022__
 

--- a/lib/src/interactions.dart
+++ b/lib/src/interactions.dart
@@ -71,6 +71,9 @@ abstract class IInteractions {
   /// Fetches all guild commands for given guild
   Stream<ISlashCommand> fetchGuildCommands(Snowflake guildId);
 
+  /// Returns the global overrides for commands in a guild.
+  Cacheable<Snowflake, ISlashCommandPermissionOverrides> getGlobalOverridesInGuild(Snowflake guildId);
+
   static IInteractions create(InteractionBackend backend) => Interactions(backend);
 }
 
@@ -311,6 +314,10 @@ class Interactions implements IInteractions {
   /// Fetches all guild commands for given guild
   @override
   Stream<ISlashCommand> fetchGuildCommands(Snowflake guildId) => interactionsEndpoints.fetchGuildCommands(client.appId, guildId);
+
+  @override
+  Cacheable<Snowflake, ISlashCommandPermissionOverrides> getGlobalOverridesInGuild(Snowflake guildId) =>
+      SlashCommandPermissionOverridesCacheable(client.appId, guildId, this);
 
   void _extractCommandIds(List<ISlashCommand> commands) {
     for (final slashCommand in commands) {

--- a/lib/src/internal/interaction_endpoints.dart
+++ b/lib/src/internal/interaction_endpoints.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:logging/logging.dart';
 import 'package:nyxx/nyxx.dart';
 import 'package:nyxx/src/core/message/message.dart';
 import 'package:nyxx_interactions/nyxx_interactions.dart';
@@ -92,6 +93,8 @@ abstract class IInteractionsEndpoints {
 class InteractionsEndpoints implements IInteractionsEndpoints {
   final INyxx _client;
   final Interactions _interactions;
+
+  final Logger _logger = Logger('Interactions');
 
   InteractionsEndpoints(this._client, this._interactions);
 
@@ -395,10 +398,12 @@ class InteractionsEndpoints implements IInteractionsEndpoints {
         // 10066 = Unknown application command permissions
         // Means there are no overrides for this command... why is this an error, Discord?
         if (jsonDecode(response.errorMessage)['code'] == 10066) {
+          _logger.finest('Got error code 10066 on permissions for command $commandId in guild $guildId, returning empty permission overrides.');
           return SlashCommandPermissionOverrides.empty(commandId, _client);
         }
       } on Exception {
         // We got invalid JSON. The request is probably invalid, so we ignore it and return an error.
+        _logger.warning('Invalid JSON in response: ${response.errorMessage}');
       }
 
       return Future.error(response);

--- a/lib/src/models/slash_command_permission.dart
+++ b/lib/src/models/slash_command_permission.dart
@@ -59,17 +59,29 @@ class SlashCommandPermissionOverride implements ISlashCommandPermissionOverride 
 abstract class ISlashCommandPermissionOverrides implements SnowflakeEntity {
   /// The permissions attached to the command.
   List<SlashCommandPermissionOverride> get permissionOverrides;
+
+  /// Whether these overrideas are global across all commands in a guild.
+  bool get isGlobal;
 }
 
 class SlashCommandPermissionOverrides extends SnowflakeEntity implements ISlashCommandPermissionOverrides {
   @override
   late final List<SlashCommandPermissionOverride> permissionOverrides;
+  @override
+  late final bool isGlobal;
 
   SlashCommandPermissionOverrides(RawApiMap raw, INyxx client) : super(Snowflake(raw['id'])) {
     permissionOverrides = [
       for (final override in (raw['permissions'] as List<dynamic>).cast<Map<String, dynamic>>())
         SlashCommandPermissionOverride(override, Snowflake(raw["guild_id"]), client),
     ];
+
+    isGlobal = id == client.appId;
+  }
+
+  SlashCommandPermissionOverrides.empty(Snowflake commandId, INyxx client) : super(commandId) {
+    permissionOverrides = [];
+    isGlobal = id == client.appId;
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx_interactions
-version: 4.2.0
+version: 4.2.1
 description: Nyxx Interactions Module. Discord library for Dart. Simple, robust framework for creating discord bots for Dart language.
 homepage: https://github.com/nyxx-discord/nyxx
 repository: https://github.com/nyxx-discord/nyxx


### PR DESCRIPTION
# Description

Implements application level permission overrides that were missing from the Discord documentation, and handle an error that occurs when fetching permissions for a command that has no permission overrides.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
