### PR TITLE
BUGFIX fix interaction handling mapping for global slash command

### DIFF
--- a/lib/src/interactions.dart
+++ b/lib/src/interactions.dart
@@ -221,11 +221,17 @@ class Interactions implements IInteractions {
 
     if (_commandHandlers.isNotEmpty) {
       events.onSlashCommand.listen((event) async {
-        final commandHash = determineInteractionCommandHandler(event.interaction);
+        final globalCommandHash = determineGlobalInteractionCommandHandler(event.interaction);
+        final guildCommandHash = determineGuildInteractionCommandHandler(event.interaction);
 
-        _logger.info("Executing command with hash [$commandHash]");
-        if (_commandHandlers.containsKey(commandHash)) {
-          await _commandHandlers[commandHash]!(event);
+        if (guildCommandHash != null && _commandHandlers.containsKey(guildCommandHash)) {
+          _logger.info("Executing command with hash [$guildCommandHash]");
+          await _commandHandlers[guildCommandHash]!(event);
+        } else if (_commandHandlers.containsKey(globalCommandHash)) {
+          _logger.info("Executing command with hash [$globalCommandHash]");
+          await _commandHandlers[globalCommandHash]!(event);
+        } else {
+          _logger.warning("Failed to match command with hash [$guildCommandHash] or [$globalCommandHash]");
         }
       });
 
@@ -257,14 +263,19 @@ class Interactions implements IInteractions {
     if (_autocompleteHandlers.isNotEmpty) {
       events.onAutocompleteEvent.listen((event) {
         final name = event.focusedOption.name;
-        final commandHash = determineInteractionCommandHandler(event.interaction);
-        final autocompleteHash = "$commandHash$name";
+        final globalCommandHash = determineGlobalInteractionCommandHandler(event.interaction);
+        final guildCommandHash = determineGuildInteractionCommandHandler(event.interaction);
+        final globalAutocompleteHash = "$globalCommandHash$name";
+        final guildAutocompleteHash = "$guildCommandHash$name";
 
-        if (_autocompleteHandlers.containsKey(autocompleteHash)) {
-          _logger.info("Executing autocomplete with id [$autocompleteHash]");
-          _autocompleteHandlers[autocompleteHash]!(event);
+        if (guildCommandHash != null && _autocompleteHandlers.containsKey(guildAutocompleteHash)) {
+          _logger.info("Executing autocomplete with id [$guildAutocompleteHash]");
+          _autocompleteHandlers[guildAutocompleteHash]!(event);
+        } else if (_autocompleteHandlers.containsKey(globalAutocompleteHash)) {
+          _logger.info("Executing autocomplete with id [$globalAutocompleteHash]");
+          _autocompleteHandlers[globalAutocompleteHash]!(event);
         } else {
-          _logger.warning("Received event for unknown dropdown: $autocompleteHash");
+          _logger.warning("Received event for unknown dropdown: $globalAutocompleteHash");
         }
       });
     }

--- a/lib/src/internal/utils.dart
+++ b/lib/src/internal/utils.dart
@@ -25,11 +25,8 @@ Iterable<Iterable<T>> partition<T>(Iterable<T> list, bool Function(T) predicate)
 }
 
 /// Determine what handler should be executed based on [interaction]
-String determineInteractionCommandHandler(ISlashCommandInteraction interaction) {
+String determineGlobalInteractionCommandHandler(ISlashCommandInteraction interaction) {
   String commandHash = interaction.name;
-  if (interaction.guild != null) {
-    commandHash = '${interaction.guild!.id}/$commandHash';
-  }
 
   try {
     final subCommandGroup = interaction.options.firstWhere((element) => element.type == CommandOptionType.subCommandGroup);
@@ -46,6 +43,12 @@ String determineInteractionCommandHandler(ISlashCommandInteraction interaction) 
   } on StateError {}
 
   return commandHash;
+}
+
+/// Determine what guild handler should be executed based on [interaction]
+String? determineGuildInteractionCommandHandler(ISlashCommandInteraction interaction) {
+  if (interaction.guild == null) return null;
+  return '${interaction.guild!.id}/${determineGlobalInteractionCommandHandler(interaction)}';
 }
 
 /// Groups [SlashCommandBuilder] for registering them later in bulk


### PR DESCRIPTION
# Description
BUGFIX
Global Slash Command Interaction Handlers were not being mapped to correctly.
This would result in the interaction not being processed at all if the related slash command wasn't created for a specific guild.

## Connected issues & potential other potential problems

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
