### PR TITLE
Correctly select handler for global commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.3.1
+__01.08.2022__
+
+- bug: Fix global commands selecting guild command handlers
+
 ## 4.3.0
 __29.07.2022__
 

--- a/lib/src/interactions.dart
+++ b/lib/src/interactions.dart
@@ -221,7 +221,7 @@ class Interactions implements IInteractions {
 
     if (_commandHandlers.isNotEmpty) {
       events.onSlashCommand.listen((event) async {
-        final commandHash = determineInteractionCommandHandler(event.interaction);
+        final commandHash = determineInteractionCommandHandler(event.interaction, this);
 
         _logger.info("Executing command with hash [$commandHash]");
         if (_commandHandlers.containsKey(commandHash)) {
@@ -257,7 +257,7 @@ class Interactions implements IInteractions {
     if (_autocompleteHandlers.isNotEmpty) {
       events.onAutocompleteEvent.listen((event) {
         final name = event.focusedOption.name;
-        final commandHash = determineInteractionCommandHandler(event.interaction);
+        final commandHash = determineInteractionCommandHandler(event.interaction, this);
         final autocompleteHash = "$commandHash$name";
 
         if (_autocompleteHandlers.containsKey(autocompleteHash)) {

--- a/lib/src/internal/utils.dart
+++ b/lib/src/internal/utils.dart
@@ -1,9 +1,11 @@
 import 'package:nyxx/nyxx.dart';
 
 import 'package:nyxx_interactions/src/builders/slash_command_builder.dart';
+import 'package:nyxx_interactions/src/interactions.dart';
 import 'package:nyxx_interactions/src/models/command_option.dart';
 import 'package:nyxx_interactions/src/models/interaction_option.dart';
 import 'package:nyxx_interactions/src/models/interaction.dart';
+import 'package:nyxx_interactions/src/models/slash_command.dart';
 
 /// Slash command names and subcommands names have to match this regex
 final RegExp slashCommandNameRegex = RegExp(r"^[\w-]{1,32}$");
@@ -25,10 +27,12 @@ Iterable<Iterable<T>> partition<T>(Iterable<T> list, bool Function(T) predicate)
 }
 
 /// Determine what handler should be executed based on [interaction]
-String determineInteractionCommandHandler(ISlashCommandInteraction interaction) {
+String determineInteractionCommandHandler(ISlashCommandInteraction interaction, IInteractions interactions) {
   String commandHash = interaction.name;
-  if (interaction.guild != null) {
-    commandHash = '${interaction.guild!.id}/$commandHash';
+
+  ISlashCommand triggered = interactions.commands.firstWhere((command) => command.id == interaction.commandId);
+  if (triggered.guild != null) {
+    commandHash = '${triggered.guild!.id}/$commandHash';
   }
 
   try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx_interactions
-version: 4.3.0
+version: 4.3.1
 description: Nyxx Interactions Module. Discord library for Dart. Simple, robust framework for creating discord bots for Dart language.
 homepage: https://github.com/nyxx-discord/nyxx_interactions
 repository: https://github.com/nyxx-discord/nyxx_interactions


### PR DESCRIPTION
# Description

Fix global commands attempting to use a nonexistent guild command handler.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
