### PR TITLE
Allow messages with only components to be used as new messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.3.2
+__09.11.2022__
+
+- bug: Allow `ComponentMessageBuilder`s with only components to be used as new messages
+
 ## 4.3.1
 __01.08.2022__
 

--- a/lib/src/builders/component_builder.dart
+++ b/lib/src/builders/component_builder.dart
@@ -248,6 +248,9 @@ class ComponentMessageBuilder extends MessageBuilder {
   }
 
   @override
+  bool canBeUsedAsNewMessage() => super.canBeUsedAsNewMessage() || (componentRows != null && componentRows!.isNotEmpty);
+
+  @override
   RawApiMap build([AllowedMentions? defaultAllowedMentions]) => {
         ...super.build(allowedMentions),
         if (componentRows != null) "components": [for (final row in componentRows!) row.build()]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx_interactions
-version: 4.3.1
+version: 4.3.2
 description: Nyxx Interactions Module. Discord library for Dart. Simple, robust framework for creating discord bots for Dart language.
 homepage: https://github.com/nyxx-discord/nyxx_interactions
 repository: https://github.com/nyxx-discord/nyxx_interactions


### PR DESCRIPTION
# Description

Overrides `canBeUsedAsNewMessage()` to allow component message builders to be used as a new message with only components.

Closes #63.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
