### PR TITLE
Handle HTTP error response in acknowledge()

### DIFF
--- a/lib/src/exceptions/already_responded.dart
+++ b/lib/src/exceptions/already_responded.dart
@@ -1,9 +1,6 @@
 /// Thrown when you have already responded to an interaction
-class AlreadyRespondedError implements Error {
+class AlreadyRespondedError extends Error {
   /// Returns a string representation of this object.
   @override
   String toString() => "AlreadyRespondedError: Interaction has already been acknowledged, you can now only send channel messages (with/without source)";
-
-  @override
-  StackTrace? get stackTrace => StackTrace.empty;
 }


### PR DESCRIPTION
# Description

Adds an extra check to `acknowledge()` to throw a client-side `AlreadyRespondedError` if the server response with an already responded error.

## Connected issues & potential other potential problems

`nyxx_commands` users can often see the server responding with an error that the interaction was already responded to, despite the initial `_hasAcked` check passing. This is because of a race condition between their command callback and auto-respond, so transforming the response into a client-side error is preferable so that nyxx_commands can handle it.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
