### PR TITLE
Add an exception for unknown commands

### DIFF
--- a/lib/nyxx_interactions.dart
+++ b/lib/nyxx_interactions.dart
@@ -37,6 +37,7 @@ export 'src/events/interaction_event.dart'
         IMentionableMultiSelectInteractionEvent,
         IChannelMultiSelectInteractionEvent;
 export 'src/exceptions/already_responded.dart' show AlreadyRespondedError;
+export 'src/exceptions/command_not_found.dart' show CommandNotFoundException;
 export 'src/exceptions/interaction_expired.dart' show InteractionExpiredError;
 export 'src/exceptions/response_required.dart' show ResponseRequiredError;
 export 'src/internal/sync/commands_sync.dart' show ICommandsSync;

--- a/lib/src/exceptions/command_not_found.dart
+++ b/lib/src/exceptions/command_not_found.dart
@@ -1,0 +1,16 @@
+import 'package:nyxx_interactions/nyxx_interactions.dart';
+
+/// An error thrown when an interaction is received but nyxx_interactions cannot find a matching command model.
+///
+/// Normally this indicates that a desync between nyxx_interactions and Discord has occurred. Make sure you call [IInteractions.sync] and that there are no
+/// guild commands left undeleted.
+class CommandNotFoundException implements Exception {
+  /// The interaction containing the unknown command.
+  final ISlashCommandInteraction interaction;
+
+  /// Create a new [CommandNotFoundException].
+  CommandNotFoundException(this.interaction);
+
+  @override
+  String toString() => 'Command not found: ${interaction.commandId}';
+}

--- a/lib/src/internal/utils.dart
+++ b/lib/src/internal/utils.dart
@@ -1,6 +1,7 @@
 import 'package:nyxx/nyxx.dart';
 
 import 'package:nyxx_interactions/src/builders/slash_command_builder.dart';
+import 'package:nyxx_interactions/src/exceptions/command_not_found.dart';
 import 'package:nyxx_interactions/src/interactions.dart';
 import 'package:nyxx_interactions/src/models/command_option.dart';
 import 'package:nyxx_interactions/src/models/interaction_option.dart';
@@ -30,7 +31,11 @@ Iterable<Iterable<T>> partition<T>(Iterable<T> list, bool Function(T) predicate)
 String determineInteractionCommandHandler(ISlashCommandInteraction interaction, IInteractions interactions) {
   String commandHash = interaction.name;
 
-  ISlashCommand triggered = interactions.commands.firstWhere((command) => command.id == interaction.commandId);
+  ISlashCommand triggered = interactions.commands.firstWhere(
+    (command) => command.id == interaction.commandId,
+    orElse: () => throw CommandNotFoundException(interaction),
+  );
+
   if (triggered.guild != null) {
     commandHash = '${triggered.guild!.id}/$commandHash';
   }


### PR DESCRIPTION
# Description

Adds a nicer error message for when a desync between nyxx_interactions and Discord occurs. Previously a `StateError` was thrown which didn't give much information about the problem.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
